### PR TITLE
Fix typo

### DIFF
--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -46,7 +46,7 @@ export default class PageFooter extends Vue {
                     link: 'https://vechainstats.com'
                 },
                 {
-                    name: 'VeBlcoks',
+                    name: 'VeBlocks',
                     link: 'https://www.veblocks.net'
                 }
             ]


### PR DESCRIPTION
Fix a typo in the url label to VeBlocks.